### PR TITLE
Fix .NET Core 3.X/.NET 5 WinForm Icon Issues

### DIFF
--- a/FontAwesome.Sharp/WinForms/FormsIconHelper.cs
+++ b/FontAwesome.Sharp/WinForms/FormsIconHelper.cs
@@ -118,6 +118,7 @@ namespace FontAwesome.Sharp
 
         internal static FontFamily FontFamilyFor(IconChar iconChar)
         {
+            if (Fonts == null) throw new Exception("FontAwesome source font files not found!");
             var name = IconHelper.FontFor(iconChar)?.Source;
             if (name == null) return FallbackFont;
             return Fonts.Families.FirstOrDefault(f => name.EndsWith(f.Name)) ?? FallbackFont;

--- a/FontAwesome.Sharp/WinForms/FormsIconHelper.cs
+++ b/FontAwesome.Sharp/WinForms/FormsIconHelper.cs
@@ -118,7 +118,7 @@ namespace FontAwesome.Sharp
 
         internal static FontFamily FontFamilyFor(IconChar iconChar)
         {
-            if (Fonts == null) throw new Exception("FontAwesome source font files not found!");
+            if (Fonts == null) throw new InvalidOperationException("FontAwesome source font files not found!");
             var name = IconHelper.FontFor(iconChar)?.Source;
             if (name == null) return FallbackFont;
             return Fonts.Families.FirstOrDefault(f => name.EndsWith(f.Name)) ?? FallbackFont;


### PR DESCRIPTION
This should resolve these two issues: #47 #46 

**TL;DR:** The issue stems from the order in which the new runtime in .NET Core initializes static fields.

**Details:** In `FormsIconHelper.FontFamilyFor()` the static field `FormsIconHelper.Fonts` is not accessed yet and thus does not load the actual packaged font data resources, causing the call to [Typeface.TryGetGlyphTypeface(GlyphTypeface)](https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.typeface.trygetglyphtypeface?view=netcore-3.1) to fail as the font isn't actually loaded into memory/`PrivateFontCollection` yet.

**Commit Notes:** _Added a field accessor to trigger the field initialization. Get error checking for free!_