### PR TITLE
Add support for showing Pro icons in Design Mode

### DIFF
--- a/FontAwesome.Sharp/WPF/IconHelper.cs
+++ b/FontAwesome.Sharp/WPF/IconHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -52,6 +53,7 @@ public static class IconHelper
     /// <returns></returns>
     public static FontFamily LoadFont(this Assembly assembly, string path, string fontTitle)
     {
+        if (DesignerProperties.GetIsInDesignMode(new DependencyObject()) && assembly == Assembly.GetEntryAssembly()) return new FontFamily(new Uri(AppDomain.CurrentDomain.BaseDirectory), $"./{path}/#{fontTitle}");
         return new FontFamily(BaseUri, $"./{assembly.GetName().Name};component/{path}/#{fontTitle}");
     }
 


### PR DESCRIPTION
When including Pro fonts in a local project, it'll fail to load the fonts due to `Assembly.GetEntryAssembly()` being `WpfSurface` in Design Mode - hence won't load the proper project asssemply resources, neither for `IconBlock` nor `IconImage`:
![billede](https://github.com/awesome-inc/FontAwesome.Sharp/assets/317552/c012c0c2-c874-40bc-9aca-48b0114bde20)

It also triggers an Exception with `Value cannot be null. (Parameter 'fontFamily')` for `IconBlock`:
![billede](https://github.com/awesome-inc/FontAwesome.Sharp/assets/317552/e8684361-4ecd-4123-b5ec-ab749f34e90c)

Above example with code in the `TestWpf`-project:
```xaml
<StackPanel Grid.Row="9" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Center">
    <faPro:IconBlock IconFont="Solid" Icon="WifiExclamation" fa:Awesome.Flip="Horizontal" FontSize="32" ToolTip="Flipped horizontally" Width="142" />
    <faPro:IconImage IconFont="Solid" Icon="WifiExclamation" fa:Awesome.Flip="Vertical" ToolTip="Flipped vertically" />
</StackPanel>
```

The `%LocalAppData%\Microsoft\VisualStudio\<version reference>\Designer\Cache\<internal project build path>` includes the fonts path (with the tff-files), in addition to the project assemply as well.

However, the next issue in this regards is, that even though a InitializeWpf function exists, this is within an internal class - and not available. In addition, doesn't seems to make much of a change even by trying to start early.

*That said, there might be a more proper solution, to handle this particular scenario - just was without luck when trying...*